### PR TITLE
Fix DTO deserialization for dictionary parser

### DIFF
--- a/app/src/main/java/com/timofeev/words/data/dto/WordDetailsResponse.kt
+++ b/app/src/main/java/com/timofeev/words/data/dto/WordDetailsResponse.kt
@@ -1,3 +1,5 @@
 package com.timofeev.words.data.dto
 
-class WordDetailsResponse(override var resultCode: Int) : ArrayList<WordDetailsResponseItem>(), Response
+class WordDetailsResponse : ArrayList<WordDetailsResponseItem>(), Response {
+    override var resultCode: Int = 0
+}

--- a/app/src/test/java/com/timofeev/words/data/dto/WordDetailsResponseParsingTest.kt
+++ b/app/src/test/java/com/timofeev/words/data/dto/WordDetailsResponseParsingTest.kt
@@ -1,0 +1,34 @@
+package com.timofeev.words.data.dto
+
+import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class WordDetailsResponseParsingTest {
+
+    @Test
+    fun `gson parses dictionary response into list dto`() {
+        val json = """
+            [
+              {
+                "word": "hello",
+                "phonetics": [{"text": "/həˈləʊ/", "audio": "https://example.com/audio.mp3"}],
+                "meanings": [
+                  {
+                    "partOfSpeech": "noun",
+                    "definitions": [{"definition": "A greeting", "example": "Hello, world!"}]
+                  }
+                ]
+              }
+            ]
+        """.trimIndent()
+
+        val parsed = Gson().fromJson(json, WordDetailsResponse::class.java)
+
+        assertNotNull(parsed)
+        assertEquals(1, parsed.size)
+        assertEquals("hello", parsed.first().word)
+        assertEquals("noun", parsed.first().meanings?.first()?.partOfSpeech)
+    }
+}


### PR DESCRIPTION
### Motivation
- The `WordDetailsResponse` DTO required a constructor argument (`resultCode`) which prevented Gson/Retrofit from deserializing the API JSON array into the list DTO correctly.

### Description
- Changed `WordDetailsResponse` to a no-argument class `class WordDetailsResponse : ArrayList<WordDetailsResponseItem>(), Response { override var resultCode: Int = 0 }` so Gson can instantiate it when parsing an array.
- Added a unit test `app/src/test/java/com/timofeev/words/data/dto/WordDetailsResponseParsingTest.kt` that uses `Gson` to parse a sample dictionary JSON array and asserts the parsed `word` and `partOfSpeech` values.

### Testing
- Added an automated unit test file, but running `./gradlew testDebugUnitTest` in this environment failed due to Gradle wrapper download being blocked by a network proxy (`HTTP/1.1 403 Forbidden`), so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b666e94d208333afd5d3d0decdf890)